### PR TITLE
Windows Command Line Init

### DIFF
--- a/init.cmd
+++ b/init.cmd
@@ -1,0 +1,20 @@
+mkdir electron-sample\app
+mkdir electron-sample\browser\scripts\splash
+cd electron-sample
+type NUL > Gulpfile.js
+type NUL > app\index.es6.js
+type NUL > browser/index.html
+type NUL > browser/scripts/splash/app.js
+type NUL > browser/scripts/splash/controller.js
+
+echo "project structure created.. installing global node modules..."
+npm i gulp electron-prebuilt jspm -g
+
+echo "initializing npm package"
+npm init
+
+echo "global dependencies installed... installing local dependencies"
+npm i gulp-babel gulp-rename gulp-run --save-dev
+
+echo "dependencies installed..."
+echo "run jspm install"

--- a/init.cmd
+++ b/init.cmd
@@ -3,9 +3,9 @@ mkdir electron-sample\browser\scripts\splash
 cd electron-sample
 type NUL > Gulpfile.js
 type NUL > app\index.es6.js
-type NUL > browser/index.html
-type NUL > browser/scripts/splash/app.js
-type NUL > browser/scripts/splash/controller.js
+type NUL > browser\index.html
+type NUL > browser\scripts\splash\app.js
+type NUL > browser\scripts\splash\controller.js
 
 echo "project structure created.. installing global node modules..."
 npm i gulp electron-prebuilt jspm -g


### PR DESCRIPTION
In the spirit of electron's cross OS support, I have added an init.cmd which can be run on windows machines in place of the init.sh
