### PR TITLE
Fix app JSPM client baseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This is a fork of the work of Thorsten Hans (original README below), corrected, completed, updated and adapted to my needs.
 
-## Caveat
-Whenever you ran 'jspm init' correct line 2 of browser/config.js to:
-
-``baseURL: __dirname + "/",``
-
-
 ----------------
 original README (at time of fork):
 ----------------

--- a/app/browser/config.js
+++ b/app/browser/config.js
@@ -1,5 +1,5 @@
 System.config({
-  baseURL: __dirname + "/",
+  baseURL: ".",
   defaultJSExtensions: true,
   transpiler: "babel",
   babelOptions: {


### PR DESCRIPTION
The "file://" URL handler requires the full path to the html file. Before
this commit, this was accomplished by modifying the jspm-generated
config.js file. It was necessary to do it every time jspm init/install was
run, as config.js does not support dynamic values.

This commit fixes this issue by setting the client baseUrl to "." in the
jspm init wizard. As a result, client baseUrl is preserved by jspm.
